### PR TITLE
Export IUniverseDriver and UniverseData

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,15 @@ import { NullDriver } from './drivers/null';
 import { SocketIODriver } from './drivers/socketio';
 import { EnttecOpenUSBDMXDriver } from './drivers/enttec-open-usb-dmx';
 import { SACNDriver } from './drivers/sacn';
+import { IUniverseDriver, UniverseData } from './models/IUniverseDriver';
 
 export {
   DMX,
   Animation,
+};
+export {
+  IUniverseDriver,
+  UniverseData
 };
 export {
   ArtnetDriver,


### PR DESCRIPTION
Export the `IUniverseDriver` and `UniverseData` to the user as their types are used (see e.g. examples where `universe.updateAll(0);`)